### PR TITLE
fix README to correct quicker start for spark and hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Go to the bash shell on the namenode with that same Container ID of the namenode
 Create a HDFS directory /data//openbeer/breweries.
 
 ```
-  hdfs dfs -mkdir /data
-  hdfs dfs -mkdir /data/openbeer
-  hdfs dfs -mkdir /data/openbeer/breweries
+  hdfs dfs -mkdir -p /data/openbeer/breweries
 ```
 
 Copy breweries.csv to HDFS:
@@ -67,7 +65,7 @@ Go to the command line of the Spark master and start PySpark.
 
 Load breweries.csv from HDFS.
 ```
-  brewfile = spark.read.csv("hdfs://namenode:8020/data/openbeer/breweries/breweries.csv")
+  brewfile = spark.read.csv("hdfs://namenode:9000/data/openbeer/breweries/breweries.csv")
   
   brewfile.show()
 +----+--------------------+-------------+-----+---+
@@ -113,7 +111,7 @@ Go to the command line of the Spark master and start spark-shell.
 
 Load breweries.csv from HDFS.
 ```
-  val df = spark.read.csv("hdfs://namenode:8020/data/openbeer/breweries/breweries.csv")
+  val df = spark.read.csv("hdfs://namenode:9000/data/openbeer/breweries/breweries.csv")
   
   df.show()
 +----+--------------------+-------------+-----+---+
@@ -167,7 +165,7 @@ tcp        0      0 0.0.0.0:10000           0.0.0.0:*               LISTEN      
 Okay. Beeline is the command line interface with Hive. Let's connect to hiveserver2 now.
 
 ```
-  beeline
+  beeline -u jdbc:hive2://localhost:10000 -n root
   
   !connect jdbc:hive2://127.0.0.1:10000 scott tiger
 ```

--- a/hadoop-hive.env
+++ b/hadoop-hive.env
@@ -6,7 +6,7 @@ HIVE_SITE_CONF_datanucleus_autoCreateSchema=false
 HIVE_SITE_CONF_hive_metastore_uris=thrift://hive-metastore:9083
 HDFS_CONF_dfs_namenode_datanode_registration_ip___hostname___check=false
 
-CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+CORE_CONF_fs_defaultFS=hdfs://namenode:9000
 CORE_CONF_hadoop_http_staticuser_user=root
 CORE_CONF_hadoop_proxyuser_hue_hosts=*
 CORE_CONF_hadoop_proxyuser_hue_groups=*


### PR DESCRIPTION
Thanks for making this convenient docker and it really helps. However I got some errors when going throng the readme tutorial. I make this simple fix so more people will benefit from your work.

First, the README gives the wrong the hdfs port, which should be 9000 defined in docker-compose.yml but 8020 is given. It makes the spark scripts fail to connection the hdfs. Also it causes the failure of hiveserver2.

In addition, run `beeline` without hive server URL would cause the `No current connection` error when querying, so the server URL is specified with this bug.